### PR TITLE
UI / Functionality Fixes

### DIFF
--- a/Assets/Prefabs/PlayerInteractionPhase_UI.prefab
+++ b/Assets/Prefabs/PlayerInteractionPhase_UI.prefab
@@ -10,7 +10,6 @@ GameObject:
   m_Component:
   - component: {fileID: 224000012389786772}
   - component: {fileID: 222000010668277768}
-  - component: {fileID: 114000011330294042}
   m_Layer: 5
   m_Name: Goal_Panel
   m_TagString: Untagged
@@ -34,7 +33,7 @@ RectTransform:
   - {fileID: 224000011432521402}
   - {fileID: 224000011951482776}
   m_Father: {fileID: 224000011781466348}
-  m_RootOrder: 10
+  m_RootOrder: 14
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -49,35 +48,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1000010023997134}
   m_CullTransparentMesh: 0
---- !u!114 &114000011330294042
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1000010023997134}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 0.74509805}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 0}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
 --- !u!1 &1000010056320036
 GameObject:
   m_ObjectHideFlags: 0
@@ -1286,11 +1256,11 @@ RectTransform:
   - {fileID: 224000011683073842}
   - {fileID: 224000011600691284}
   - {fileID: 224000012134658544}
-  - {fileID: 224000012389786772}
   - {fileID: 224961489778609658}
   - {fileID: 224000013890215990}
   - {fileID: 224000014293434984}
   - {fileID: 8440694687463296163}
+  - {fileID: 224000012389786772}
   - {fileID: 224000011168393594}
   - {fileID: 224000011923579736}
   - {fileID: 224000012877272790}
@@ -1386,6 +1356,7 @@ MonoBehaviour:
         isOpen: 0
       waitForUserInput: 0
       userInput: 0
+      pi_gpb: {fileID: 114000011069610498}
     UIOverlay_Hint_Container: {fileID: 224000012128283596}
     hint_button_container: {fileID: 224000011530368368}
     hintOverlay:
@@ -1414,8 +1385,11 @@ MonoBehaviour:
       panelContainer: {fileID: 224000012209610702}
       isOpen: 0
     place_semaphore: {fileID: 114000012188733926}
+    place_semaphoreButton: {fileID: 114000013781415136}
     place_button: {fileID: 114000010431845708}
+    place_buttonButton: {fileID: 114000010033894540}
     trash: {fileID: 114000010808615036}
+    trashButton: {fileID: 114000011110400788}
     preview: {fileID: 114000013697017244}
     simulationButton: {fileID: 114000013890134070}
     stopSimulationButton: {fileID: 114000010227598758}
@@ -2550,7 +2524,7 @@ RectTransform:
   m_Children:
   - {fileID: 224000011284683332}
   m_Father: {fileID: 224000011781466348}
-  m_RootOrder: 13
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -10233,7 +10207,7 @@ RectTransform:
   - {fileID: 224034096934248388}
   - {fileID: 224000011187673574}
   m_Father: {fileID: 224000011781466348}
-  m_RootOrder: 12
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -14515,7 +14489,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 224000011781466348}
-  m_RootOrder: 11
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
@@ -14754,7 +14728,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 224000011781466348}
-  m_RootOrder: 14
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}

--- a/Assets/Scenes/main.unity
+++ b/Assets/Scenes/main.unity
@@ -705,6 +705,16 @@ PrefabInstance:
       propertyPath: playerInteraction_UI.onHoverLightbox.lightboxElement
       value: 
       objectReference: {fileID: 686196261}
+    - target: {fileID: 114000011069610498, guid: acaefe53ffe7bfb4b97b84c82f1cf840,
+        type: 3}
+      propertyPath: playerInteraction_UI.goalDescriptionOverlay.pi_gpb
+      value: 
+      objectReference: {fileID: 644581664}
+    - target: {fileID: 114000011069610498, guid: acaefe53ffe7bfb4b97b84c82f1cf840,
+        type: 3}
+      propertyPath: playerInteraction_UI.goalDescriptionOverlay.playback
+      value: 
+      objectReference: {fileID: 1449588229}
     - target: {fileID: 224000012064912602, guid: acaefe53ffe7bfb4b97b84c82f1cf840,
         type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -1117,6 +1127,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000010519043950, guid: acaefe53ffe7bfb4b97b84c82f1cf840,
+        type: 3}
+      propertyPath: m_Color.a
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 114000012098485578, guid: acaefe53ffe7bfb4b97b84c82f1cf840, type: 3}
@@ -2259,6 +2274,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: -1862395651, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1449588229 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 114000012409007930, guid: acaefe53ffe7bfb4b97b84c82f1cf840,
+    type: 3}
+  m_PrefabInstance: {fileID: 790319443}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b3ee7b397e6b42947871ad77c03b2a3a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &1457013329

--- a/Assets/Scripts/GamePhaseBehaviors/Player Interaction UI/PlayerInteractionUI.cs
+++ b/Assets/Scripts/GamePhaseBehaviors/Player Interaction UI/PlayerInteractionUI.cs
@@ -26,8 +26,11 @@ public class PlayerInteraction_UI
 
 	[Header("Banner Event Triggers")]
 	public EventTrigger place_semaphore;
+	public Button place_semaphoreButton;
 	public EventTrigger place_button;
+	public Button place_buttonButton;
 	public EventTrigger trash;
+	public Button trashButton;
 	public EventTrigger preview;
 	//public EventTrigger exit;
 	public Button simulationButton;
@@ -212,6 +215,8 @@ public class PlayerInteraction_UI
 
         bool visibilityToggle = true;
         bool[] visibilitySettings = new bool[] { false, false, false };
+		
+		public PlayerInteraction_GamePhaseBehavior pi_gpb;
 
 		public override void OpenPanel()
 		{
@@ -221,12 +226,16 @@ public class PlayerInteraction_UI
             confirmExitOverlay.ClosePanel(true);
             confirmLevelsOverlay.ClosePanel(true);
 			EnableButtonBehaviors();
+			
+			pi_gpb.playerInteraction_UI.overlayBackground.SetTargetAlpha(1f);
 		}
 
 		public override void ClosePanel(bool forceClose = false) 
 		{
 			waitForUserInput = false;
 			base.ClosePanel(forceClose);
+			
+			pi_gpb.playerInteraction_UI.overlayBackground.SetTargetAlpha(0f);
 		}
 
         public void OpenRootScreen()

--- a/Assets/Scripts/GamePhaseBehaviors/PlayerInteraction_GamePhaseBehavior.cs
+++ b/Assets/Scripts/GamePhaseBehaviors/PlayerInteraction_GamePhaseBehavior.cs
@@ -500,7 +500,9 @@ public class PlayerInteraction_GamePhaseBehavior : GamePhaseBehavior {
     [ContextMenu("Reset Placed Objects")]
     public void ResetPlacedObjects()
     {
-        GameManager.Instance.GetGridManager().ClearGrid(false);
+		if (interactionPhase == InteractionPhases.ingame_default || interactionPhase == InteractionPhases.ingame_help) {
+			GameManager.Instance.GetGridManager().ClearGrid(false);
+		}
     }
 
     public void TriggerTutorialSimulation()
@@ -640,157 +642,179 @@ public class PlayerInteraction_GamePhaseBehavior : GamePhaseBehavior {
 		{
             // Default Phase
 			case InteractionPhases.ingame_default:
-				if(playerInteraction_UI.IsSubPanelOpen()) return;
-                /*
-                 * if player LEFT clicks during basic play, they can 
-                 * (1) Click and drag movable elements
-                */
-                if (mouseInput == MouseInput.LeftMouse)
-                {
-                    if (GameManager.Instance.GetGridManager().IsEditableElement(Input.mousePosition))
-                    {
-                        currentGridObject = GameManager.Instance.GetGridManager().RetrieveEditableGridObject(Input.mousePosition);
-                        currentGridObject.BeginDrag();
-                        interactionPhase = InteractionPhases.ingame_dragging;
-                        GameManager.Instance.tracker.CreateEventExt("BeginReposition", currentGridObject.component.type);
+		
+			if (!playerInteraction_UI.place_semaphoreButton.enabled) {
+				playerInteraction_UI.place_semaphoreButton.enabled = true;
+			}
+			if (!playerInteraction_UI.place_buttonButton.enabled) {
+				playerInteraction_UI.place_buttonButton.enabled = true;
+			}
+			if (!playerInteraction_UI.trashButton.enabled) {
+				playerInteraction_UI.trashButton.enabled = true;
+			}
+			
+			if(playerInteraction_UI.IsSubPanelOpen()) return;
+			/*
+			 * if player LEFT clicks during basic play, they can 
+			 * (1) Click and drag movable elements
+			*/
+			if (mouseInput == MouseInput.LeftMouse)
+			{
+				if (GameManager.Instance.GetGridManager().IsEditableElement(Input.mousePosition))
+				{
+					currentGridObject = GameManager.Instance.GetGridManager().RetrieveEditableGridObject(Input.mousePosition);
+					currentGridObject.BeginDrag();
+					interactionPhase = InteractionPhases.ingame_dragging;
+					GameManager.Instance.tracker.CreateEventExt("BeginReposition", currentGridObject.component.type);
 
-                        if (currentGridObject.component.type == "signal" && connectVisibilityLock)
-                        {
-                            Signal_GridObjectBehavior s = (Signal_GridObjectBehavior)currentGridObject;
-                            s.SetHighlight(false);
-                        }
-                    }
-                    else
-                    {
-                        if(dragging == false)
-                        {
-                            UpdatePan();
-                        }
-                    }
-                    if (hoverObject)
-                    {
-                        if (!connectVisibility) hoverObject.EndHoverBehavior();
-                        hoverObject = null;
-                    }
-                }
-                /*
-                * if player RIGHT clicks during basic play, they can:
-                * (1) link connectable elements through Signals
-                * (2) Open/Close Semaphores
-               */
-                else if (mouseInput == MouseInput.RightMouse)
-                {
-                    if (GameManager.Instance.GetGridManager().IsObjectOfType(Input.mousePosition, "signal") && GameManager.Instance.GetGridManager().IsEditableElement( Input.mousePosition ) )
-                    {
-                        currentGridObject = GameManager.Instance.GetGridManager().RetrieveGridObjectOfType(Input.mousePosition, "signal");
-                        currentGridObject.EnableGridObjectEventBehaviors(GridObjectBehavior.InteractTypes.rightClick);
-                        interactionPhase = InteractionPhases.ingame_connecting;
-                        currentGridObject.BeginInteraction();
+					if (currentGridObject.component.type == "signal" && connectVisibilityLock)
+					{
+						Signal_GridObjectBehavior s = (Signal_GridObjectBehavior)currentGridObject;
+						s.SetHighlight(false);
+					}
+				}
+				else
+				{
+					if(dragging == false)
+					{
+						UpdatePan();
+					}
+				}
+				if (hoverObject)
+				{
+					if (!connectVisibility) hoverObject.EndHoverBehavior();
+					hoverObject = null;
+				}
+			}
+			/*
+			* if player RIGHT clicks during basic play, they can:
+			* (1) link connectable elements through Signals
+			* (2) Open/Close Semaphores
+		   */
+			else if (mouseInput == MouseInput.RightMouse)
+			{
+				if (GameManager.Instance.GetGridManager().IsObjectOfType(Input.mousePosition, "signal") && GameManager.Instance.GetGridManager().IsEditableElement( Input.mousePosition ) )
+				{
+					currentGridObject = GameManager.Instance.GetGridManager().RetrieveGridObjectOfType(Input.mousePosition, "signal");
+					currentGridObject.EnableGridObjectEventBehaviors(GridObjectBehavior.InteractTypes.rightClick);
+					interactionPhase = InteractionPhases.ingame_connecting;
+					currentGridObject.BeginInteraction();
 
-                        List<GridObjectBehavior> otherSignals = GameManager.Instance.GetGridManager().GetGridComponentsOfType(new List<string>() { "signal" });
-                        foreach (GridObjectBehavior otherSignal in otherSignals)
-                        {
-                            if (currentGridObject != otherSignal) { otherSignal.GetComponent<SpriteRenderer>().sortingOrder = Constants.ComponentSortingOrder.connectionOverlay - 1; }
-                        }
+					List<GridObjectBehavior> otherSignals = GameManager.Instance.GetGridManager().GetGridComponentsOfType(new List<string>() { "signal" });
+					foreach (GridObjectBehavior otherSignal in otherSignals)
+					{
+						if (currentGridObject != otherSignal) { otherSignal.GetComponent<SpriteRenderer>().sortingOrder = Constants.ComponentSortingOrder.connectionOverlay - 1; }
+					}
 
-                        GameManager.Instance.tracker.CreateEventExt("BeginLink", currentGridObject.component.type);
+					GameManager.Instance.tracker.CreateEventExt("BeginLink", currentGridObject.component.type);
 
-                        playerInteraction_UI.onHoverLightbox.OpenPanel();
+					playerInteraction_UI.onHoverLightbox.OpenPanel();
 
-                    }
-                    else if (GameManager.Instance.GetGridManager().IsObjectOfType(Input.mousePosition, "semaphore") && GameManager.Instance.GetGridManager().IsEditableElement(Input.mousePosition))
-                    {
-                        currentGridObject = GameManager.Instance.GetGridManager().RetrieveGridObjectOfType(Input.mousePosition, "semaphore");
-                        currentGridObject.EnableGridObjectEventBehaviors(GridObjectBehavior.InteractTypes.rightClick);
-                        currentGridObject.BeginInteraction();
-                        GameManager.Instance.tracker.CreateEventExt("BeginLink", currentGridObject.component.type);
-                    }
+				}
+				else if (GameManager.Instance.GetGridManager().IsObjectOfType(Input.mousePosition, "semaphore") && GameManager.Instance.GetGridManager().IsEditableElement(Input.mousePosition))
+				{
+					currentGridObject = GameManager.Instance.GetGridManager().RetrieveGridObjectOfType(Input.mousePosition, "semaphore");
+					currentGridObject.EnableGridObjectEventBehaviors(GridObjectBehavior.InteractTypes.rightClick);
+					currentGridObject.BeginInteraction();
+					GameManager.Instance.tracker.CreateEventExt("BeginLink", currentGridObject.component.type);
+				}
 
-                    if (hoverObject /*&& !connectVisibilityLock*/)
-                    {
-                        hoverObject.EndHoverBehavior();
-                        hoverObject = null;
-                    }
-                }
-                else if (mouseInput == MouseInput.MiddleMouse)
-                {
-                    //ResetZoom();
-                }
-                /*
-                 * if a player isn't clicking the mouse, we should check for hover behaviors AND zoom behaviors
-                */
-                else
-                {
-                    if (Input.mousePosition == stationaryMousePosition) //if mouse is stationary
-                    {
-                        if (hoverObject == null)
-                        {
-                            stationaryTime += Time.deltaTime;
-                            if (stationaryTime >= 0.2f)
-                            {
-                                if (
-                                        GameManager.Instance.GetGridManager().IsObjectOfType(Input.mousePosition, "signal")
-                                        || GameManager.Instance.GetGridManager().IsObjectOfType(Input.mousePosition, "diverter")
-                                        || GameManager.Instance.GetGridManager().IsObjectOfType(Input.mousePosition, "exchange")
-                                        || GameManager.Instance.GetGridManager().IsObjectOfType(Input.mousePosition, "delivery")
-                                        || GameManager.Instance.GetGridManager().IsObjectOfType(Input.mousePosition, "pickup")
-                                        || GameManager.Instance.GetGridManager().IsObjectOfType(Input.mousePosition, "conditional")
-                                        || GameManager.Instance.GetGridManager().IsObjectOfType(Input.mousePosition, "semaphore")
-                                    )
-                                {
-                                    hoverObject = GameManager.Instance.GetGridManager().GetGridObjectByMousePosition(Input.mousePosition);
-                                    hoverObject.OnHoverBehavior();
-                                    GameManager.Instance.tracker.CreateEventExt("OnHoverBehavior", hoverObject.component.type);
-                                }
-                            }
-                        }
+				if (hoverObject /*&& !connectVisibilityLock*/)
+				{
+					hoverObject.EndHoverBehavior();
+					hoverObject = null;
+				}
+			}
+			else if (mouseInput == MouseInput.MiddleMouse)
+			{
+				//ResetZoom();
+			}
+			/*
+			 * if a player isn't clicking the mouse, we should check for hover behaviors AND zoom behaviors
+			*/
+			else
+			{
+				if (Input.mousePosition == stationaryMousePosition) //if mouse is stationary
+				{
+					if (hoverObject == null)
+					{
+						stationaryTime += Time.deltaTime;
+						if (stationaryTime >= 0.2f)
+						{
+							if (
+									GameManager.Instance.GetGridManager().IsObjectOfType(Input.mousePosition, "signal")
+									|| GameManager.Instance.GetGridManager().IsObjectOfType(Input.mousePosition, "diverter")
+									|| GameManager.Instance.GetGridManager().IsObjectOfType(Input.mousePosition, "exchange")
+									|| GameManager.Instance.GetGridManager().IsObjectOfType(Input.mousePosition, "delivery")
+									|| GameManager.Instance.GetGridManager().IsObjectOfType(Input.mousePosition, "pickup")
+									|| GameManager.Instance.GetGridManager().IsObjectOfType(Input.mousePosition, "conditional")
+									|| GameManager.Instance.GetGridManager().IsObjectOfType(Input.mousePosition, "semaphore")
+								)
+							{
+								hoverObject = GameManager.Instance.GetGridManager().GetGridObjectByMousePosition(Input.mousePosition);
+								hoverObject.OnHoverBehavior();
+								GameManager.Instance.tracker.CreateEventExt("OnHoverBehavior", hoverObject.component.type);
+							}
+						}
+					}
 
-                        //float scrollAxis = Input.GetAxis("Mouse ScrollWheel");
-                        //if (scrollAxis != 0)
-                            //UpdateZoom(scrollAxis*-1); //invert so the scrolling works in the expected direction
-                    }
-                    else //if mouse has moved since last frame 
-                    {
-                        stationaryMousePosition = Input.mousePosition;
-                        if (hoverObject)
-                        {
-                            if (GameManager.Instance.GetGridManager().IsOccupied(Input.mousePosition))
-                            {
-                                if (hoverObject != GameManager.Instance.GetGridManager().GetGridObjectByMousePosition(Input.mousePosition))
-                                { EndHoverEvent(); }
-                            }
-                            else { EndHoverEvent(); }
-                        }
-                        else
-                        {
-                            stationaryTime = 0f;
-                        }
+					//float scrollAxis = Input.GetAxis("Mouse ScrollWheel");
+					//if (scrollAxis != 0)
+						//UpdateZoom(scrollAxis*-1); //invert so the scrolling works in the expected direction
+				}
+				else //if mouse has moved since last frame 
+				{
+					stationaryMousePosition = Input.mousePosition;
+					if (hoverObject)
+					{
+						if (GameManager.Instance.GetGridManager().IsOccupied(Input.mousePosition))
+						{
+							if (hoverObject != GameManager.Instance.GetGridManager().GetGridObjectByMousePosition(Input.mousePosition))
+							{ EndHoverEvent(); }
+						}
+						else { EndHoverEvent(); }
+					}
+					else
+					{
+						stationaryTime = 0f;
+					}
 
-                        //pop up tooltip close check
-                        if (playerInteraction_UI.tooltipOverlay.tooltipActive && Time.time - playerInteraction_UI.tooltipOverlay.openTime > 0.5f)
-                        { playerInteraction_UI.tooltipOverlay.ClosePanel(); }
-                    }
-                    stationaryMousePosition = Input.mousePosition;
-                    GridObjectBehavior hoverObject__ = GameManager.Instance.GetGridManager().GetGridObjectByMousePosition(Input.mousePosition);
-                    if (hoverObject__ != null && hoverObject__ != hoverObject_)
-                    {
-                        hoverObject_ = hoverObject__;
-                        if (hoverObject_.component != null)
-                        {
-                            GameManager.Instance.tracker.CreateEventExt("OnMouseComponent", hoverObject_.component.type.ToString() + "/" + hoverObject_.component.id.ToString());
-                        }
-                    }
-                    if (hoverObject__ == null && hoverObject_ != null)
-                    {
-                        GameManager.Instance.tracker.CreateEventExt("OutMouseComponent", hoverObject_.component.type.ToString() + "/" + hoverObject_.component.id.ToString());
-                        hoverObject_ = null;
-                    }
+					//pop up tooltip close check
+					if (playerInteraction_UI.tooltipOverlay.tooltipActive && Time.time - playerInteraction_UI.tooltipOverlay.openTime > 0.5f)
+					{ playerInteraction_UI.tooltipOverlay.ClosePanel(); }
+				}
+				stationaryMousePosition = Input.mousePosition;
+				GridObjectBehavior hoverObject__ = GameManager.Instance.GetGridManager().GetGridObjectByMousePosition(Input.mousePosition);
+				if (hoverObject__ != null && hoverObject__ != hoverObject_)
+				{
+					hoverObject_ = hoverObject__;
+					if (hoverObject_.component != null)
+					{
+						GameManager.Instance.tracker.CreateEventExt("OnMouseComponent", hoverObject_.component.type.ToString() + "/" + hoverObject_.component.id.ToString());
+					}
+				}
+				if (hoverObject__ == null && hoverObject_ != null)
+				{
+					GameManager.Instance.tracker.CreateEventExt("OutMouseComponent", hoverObject_.component.type.ToString() + "/" + hoverObject_.component.id.ToString());
+					hoverObject_ = null;
+				}
 
-                }
-			break;
+			}
+		break;
 
         // Dragging Phase
 		case InteractionPhases.ingame_dragging:
+		
+			if (!playerInteraction_UI.place_semaphoreButton.enabled) {
+				playerInteraction_UI.place_semaphoreButton.enabled = true;
+			}
+			if (!playerInteraction_UI.place_buttonButton.enabled) {
+				playerInteraction_UI.place_buttonButton.enabled = true;
+			}
+			if (!playerInteraction_UI.trashButton.enabled) {
+				playerInteraction_UI.trashButton.enabled = true;
+			}
+			
 			if(mouseInput == MouseInput.LeftMouse)
 			{
 				if( currentGridObject != null )
@@ -839,15 +863,25 @@ public class PlayerInteraction_GamePhaseBehavior : GamePhaseBehavior {
 			}
 		break;
 
-            case InteractionPhases.ingame_placing:
-                if(mouseInput == MouseInput.LeftMouse)
-                {
+		case InteractionPhases.ingame_placing:
+			if(mouseInput == MouseInput.LeftMouse)
+			{
 
-                }
-                break;
+			}
+			break;
 
         // Connection Phase
 		case InteractionPhases.ingame_connecting:
+		
+			if (!playerInteraction_UI.place_semaphoreButton.enabled) {
+				playerInteraction_UI.place_semaphoreButton.enabled = true;
+			}
+			if (!playerInteraction_UI.place_buttonButton.enabled) {
+				playerInteraction_UI.place_buttonButton.enabled = true;
+			}
+			if (!playerInteraction_UI.trashButton.enabled) {
+				playerInteraction_UI.trashButton.enabled = true;
+			}
 
 			if(mouseInput == MouseInput.RightMouse)
 			{
@@ -887,53 +921,89 @@ public class PlayerInteraction_GamePhaseBehavior : GamePhaseBehavior {
 
         // Help Phase
         case InteractionPhases.ingame_help:
-            // On Left Click
-            if (mouseInput == MouseInput.LeftMouse)
-            {
-                    Button current_button = null;
-                    Image current_image = null;
-                    GridObjectBehavior current_object = GameManager.Instance.GetGridManager().GetGridObjectByMousePosition(Input.mousePosition);
+		
+			if (!playerInteraction_UI.place_semaphoreButton.enabled) {
+				playerInteraction_UI.place_semaphoreButton.enabled = true;
+			}
+			if (!playerInteraction_UI.place_buttonButton.enabled) {
+				playerInteraction_UI.place_buttonButton.enabled = true;
+			}
+			if (!playerInteraction_UI.trashButton.enabled) {
+				playerInteraction_UI.trashButton.enabled = true;
+			}
+		
+			// On Left Click
+			if (mouseInput == MouseInput.LeftMouse)
+			{
+				Button current_button = null;
+				Image current_image = null;
+				GridObjectBehavior current_object = GameManager.Instance.GetGridManager().GetGridObjectByMousePosition(Input.mousePosition);
 
-                    //raycasting to find buttons for glossary
-                    GraphicRaycaster uiRaycast = FindObjectOfType<GraphicRaycaster>();
-                    PointerEventData uiRaycastData = new PointerEventData(FindObjectOfType<EventSystem>());
-                    uiRaycastData.position = Input.mousePosition;
-                    List<RaycastResult> uiResults = new List<RaycastResult>();
-                    uiRaycast.Raycast(uiRaycastData, uiResults);
+				//raycasting to find buttons for glossary
+				GraphicRaycaster uiRaycast = FindObjectOfType<GraphicRaycaster>();
+				PointerEventData uiRaycastData = new PointerEventData(FindObjectOfType<EventSystem>());
+				uiRaycastData.position = Input.mousePosition;
+				List<RaycastResult> uiResults = new List<RaycastResult>();
+				uiRaycast.Raycast(uiRaycastData, uiResults);
 
-                    foreach (RaycastResult r in uiResults)
-                    {
-                        if (r.gameObject.GetComponent<Button>() != null)
-                        {
-                            current_button = r.gameObject.GetComponent<Button>();
-                            break;
-                        }
-                        if (r.gameObject.GetComponent<Image>() != null)
-                        {
-                            current_image = r.gameObject.GetComponent<Image>();
-                            break;
-                        }
-                    }
+				foreach (RaycastResult r in uiResults)
+				{
+					if (r.gameObject.GetComponent<Button>() != null)
+					{
+						current_button = r.gameObject.GetComponent<Button>();
+						break;
+					}
+					if (r.gameObject.GetComponent<Image>() != null)
+					{
+						current_image = r.gameObject.GetComponent<Image>();
+						break;
+					}
+				}
 
-                    if (current_button)
-                    {
-                        string obj_name = current_button.name;
-                        TriggerHint(obj_name);
-                    }
-                    else if (current_image)
-                    {
-                        string obj_name = current_image.name;
-                        TriggerHint(obj_name);
-                    }
-                    else if (current_object)
-                    {
-                        string obj_name = current_object.component.type;
-                        if (obj_name == "delivery" || obj_name == "pickup")
-                            obj_name = current_object.name;
-                        TriggerHint(obj_name);
-                    }
-                }
-            break;
+				if (current_button)
+				{
+					string obj_name = current_button.name;
+					TriggerHint(obj_name);
+				}
+				else if (current_image)
+				{
+					string obj_name = current_image.name;
+					TriggerHint(obj_name);
+				}
+				else if (current_object)
+				{
+					string obj_name = current_object.component.type;
+					if (obj_name == "delivery" || obj_name == "pickup")
+						obj_name = current_object.name;
+					TriggerHint(obj_name);
+				}
+			}
+			break;
+				
+		// Awaiting Simulation Phase
+		case InteractionPhases.awaitingSimulation:
+			if (playerInteraction_UI.place_semaphoreButton.enabled) {
+				playerInteraction_UI.place_semaphoreButton.enabled = false;
+			}
+			if (playerInteraction_UI.place_buttonButton.enabled) {
+				playerInteraction_UI.place_buttonButton.enabled = false;
+			}
+			if (playerInteraction_UI.trashButton.enabled) {
+				playerInteraction_UI.trashButton.enabled = false;
+			}
+			break;
+			
+		case InteractionPhases.simulation:
+			if (playerInteraction_UI.place_semaphoreButton.enabled) {
+				playerInteraction_UI.place_semaphoreButton.enabled = false;
+			}
+			if (playerInteraction_UI.place_buttonButton.enabled) {
+				playerInteraction_UI.place_buttonButton.enabled = false;
+			}
+			if (playerInteraction_UI.trashButton.enabled) {
+				playerInteraction_UI.trashButton.enabled = false;
+			}
+			break;			
 		}
 
 	}


### PR DESCRIPTION
- Implemented the Pause overlay's background fade into the Goal overlay.
- Removed the ability to use the trash bin while in a simulating (prior to this, clicking it would delete all semaphores and buttons placed by the player- had no effect on simulation though.)
- Fixed a minor graphical issue where clicking on the semaphore/button/trash button during a simulation would set them to their "pressed" sprite. This no longer occurs as they're not meant to be pressed during a simulation.